### PR TITLE
docs: heading fix 

### DIFF
--- a/docs/awesome-remnawave/index.md
+++ b/docs/awesome-remnawave/index.md
@@ -163,7 +163,7 @@ Features:
 
 Author: [maposia](https://github.com/maposia)
 
-### Environment Variables
+#### Environment Variables
 
 The application requires the following environment variables to be set:
 


### PR DESCRIPTION
[environment variables](https://remna.st/awesome/#environment-variables) has wrong heading, so it appears like another project in headings list

thats all ¯\_(ツ)_/¯