### PR TITLE
add support head meta theme-color

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -19,6 +19,16 @@ const config: Config = {
         locales: ['en']
     },
 
+    headTags: [
+        {
+            tagName: 'meta',
+            attributes: {
+                name: 'theme-color',
+                content: '#242c38',
+            },
+        },
+    ],
+
     presets: [
         [
             'classic',


### PR DESCRIPTION
based on https://docusaurus.io/docs/api/docusaurus-config#headTags