### PR TITLE
Add MTU configuration option for Warp/WireGuard in Xray

### DIFF
--- a/docs/guides/warp-outbound-over-wg.md
+++ b/docs/guides/warp-outbound-over-wg.md
@@ -95,7 +95,8 @@ Add the following to your XRAY config under `outbounds`:
         "publicKey": "YOUR_PUBLIC_KEY_FROM_FILE",
         "endpoint": "engage.cloudflareclient.com:2408"
       }
-    ]
+    ],
+    "mtu": 1280
   }
 }
 ```

--- a/docs/guides/warp-outbound-over-wg.md
+++ b/docs/guides/warp-outbound-over-wg.md
@@ -141,7 +141,9 @@ Add the following to your XRAY config under `outbounds`:
 // highlight-next-line-green
         }
 // highlight-next-line-green
-      ]
+      ],
+// highlight-next-line-green
+      "mtu": 1280
 // highlight-next-line-green
     }
 // highlight-next-line-green


### PR DESCRIPTION
Add mtu parameter to the Warp/WireGuard configuration in Xray.

Setting a specific MTU can help prevent packet fragmentation issues when tunneling traffic through Warp/Cloudflare. A value of 1280 is chosen as a safe default, which ensures compatibility across different networks and avoids potential connectivity issues.