### PR TITLE
add new applications to HWID documentation

### DIFF
--- a/docs/features/hwid-device-limit.md
+++ b/docs/features/hwid-device-limit.md
@@ -83,6 +83,8 @@ Not all client applications send a HWID header. Here is the list of applications
 - Forks by Remnawave community:
   - [Koala Clash](https://github.com/coolcoala/clash-verge-rev-lite) (Clash Verge Rev fork)
   - [FlClashX](https://github.com/pluralplay/FlClashX) (FlClash fork)
+  - [Prizrak-Box](https://github.com/legiz-ru/Prizrak-Box) (Pandora-Box fork)
+- [Throne](https://github.com/throneproj/Throne/) - HWID [disabled by default](https://github.com/throneproj/Throne/pull/789)
 
 ## For app developers
 


### PR DESCRIPTION
Added a link to Prizrak-Box and clarified HWID status for Throne.