### PR TITLE
Fix formatting of migration command in marzban.md

### DIFF
--- a/docs/migrate/marzban.md
+++ b/docs/migrate/marzban.md
@@ -61,11 +61,11 @@ The migration tool uses command-line flags for configuration. Below is an exampl
 ```bash
 ./remnawave-migrate \
   --panel-type=marzban \
-  --panel-url="https://your-marzban-server" \
-  --panel-username="admin" \
-  --panel-password="your-admin-password" \
-  --remnawave-url="https://your-remnawave-server" \
-  --remnawave-token="your-remnawave-token" \
+  --panel-url=https://your-marzban-server \
+  --panel-username=admin \
+  --panel-password=your-admin-password \
+  --remnawave-url=https://your-remnawave-server \
+  --remnawave-token=your-remnawave-token \
   --preserve-status
 ```
 


### PR DESCRIPTION
Удалил ковычки для команды миграции. Они там не требуется и стоят не корректно, если запросить команду ./remnawave-migrate --help она покажет что нужно все делать строками без ковычек