### PR TITLE
fix nginx tinyauth snippet in docs

### DIFF
--- a/docs/install/panel-security/tinyAuth-for-nginx.md
+++ b/docs/install/panel-security/tinyAuth-for-nginx.md
@@ -128,6 +128,8 @@ server {
 location /tinyauth {
   proxy_pass http://tinyauth/api/auth/nginx;
 
+  proxy_pass_request_body off;
+  proxy_set_header Content-Length "";
   proxy_set_header x-forwarded-proto $scheme;
   proxy_set_header x-forwarded-host $http_host;
   proxy_set_header x-forwarded-uri $request_uri;


### PR DESCRIPTION
### Summary
This PR fixes an issue in the Nginx configuration example within the `panel-security` documentation. Without this fix, Nginx throws a `504 Gateway Timeout` when processing `POST` requests to `/api/auth/login`.

### Problem
In the provided Nginx example, the `auth_request` directive forwards the original headers (including `Content-Length`) to the `tinyauth` upstream during a login `POST` request, but it strips the actual request body. This causes the upstream service to wait indefinitely for a payload that never arrives, leading to a connection timeout.

### Solution
Updated the `/tinyauth` location block snippet in the documentation to include:
* `proxy_pass_request_body off;`
* `proxy_set_header Content-Length "";`

This ensures Nginx correctly signals to `tinyauth` that no body is expected for the subrequest, fixing the login hang.