### PR TITLE
feat(clients): add InHive client

### DIFF
--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -632,6 +632,25 @@ export const CLIENTS: Client[] = [
         links: {
             github: 'https://github.com/mihail-jdanov/DeskBox'
         }
+    },
+    {
+        id: 'inhive',
+        name: 'InHive',
+        core: 'singbox',
+        platforms: ['android', 'windows'],
+        description:
+            'Invite-only VPN client built on sing-box, with modern protocols (Reality, Hysteria2, TUIC).',
+        logo: '/clients/logo/inhive-dark.svg',
+        badges: {
+            hwid: true
+        },
+        downloadLinks: {
+            android: 'https://github.com/TwilgateLabs/inhive-android/releases/latest',
+            windows: 'https://github.com/TwilgateLabs/inhive-windows/releases/latest'
+        },
+        links: {
+            website: 'https://inhive.ru'
+        }
     }
 ]
 

--- a/static/clients/logo/inhive-dark.svg
+++ b/static/clients/logo/inhive-dark.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+  <defs>
+    <!-- Background gradient -->
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#2a2a2e"/>
+      <stop offset="1" stop-color="#111113"/>
+    </linearGradient>
+    <!-- Top edge highlight -->
+    <linearGradient id="edge" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#fff" stop-opacity=".12"/>
+      <stop offset=".04" stop-color="#fff" stop-opacity=".04"/>
+      <stop offset=".1" stop-color="#fff" stop-opacity="0"/>
+    </linearGradient>
+    <!-- Symbol gradient -->
+    <linearGradient id="sym" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#ffffff"/>
+      <stop offset="1" stop-color="#d0d0d4"/>
+    </linearGradient>
+    <!-- Drop shadow -->
+    <filter id="sh" x="-.08" y="-.04" width="1.16" height="1.2">
+      <feDropShadow dx="0" dy="6" stdDeviation="18" flood-color="#000" flood-opacity=".55"/>
+    </filter>
+  </defs>
+  <!-- Shadow layer -->
+  <rect x="128" y="128" width="768" height="768" rx="178" fill="#000" filter="url(#sh)"/>
+  <!-- Background -->
+  <rect x="128" y="128" width="768" height="768" rx="178" fill="url(#bg)"/>
+  <!-- Top highlight -->
+  <rect x="128" y="128" width="768" height="768" rx="178" fill="url(#edge)"/>
+  <!-- Symbol -->
+  <path fill="url(#sym)" fill-rule="evenodd" d="
+    M512 258 L659 343 L659 511 L569 564
+    C569 564 512 771 512 765
+    C512 771 455 564 455 564
+    L365 511 L365 343 Z
+    M512 297 L625 364 L625 490 L512 556 L399 490 L399 364 Z"/>
+</svg>

--- a/static/clients/logo/inhive-dark.svg
+++ b/static/clients/logo/inhive-dark.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+<svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="128 128 768 768">
   <defs>
     <!-- Background gradient -->
     <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
@@ -16,13 +16,7 @@
       <stop offset="0" stop-color="#ffffff"/>
       <stop offset="1" stop-color="#d0d0d4"/>
     </linearGradient>
-    <!-- Drop shadow -->
-    <filter id="sh" x="-.08" y="-.04" width="1.16" height="1.2">
-      <feDropShadow dx="0" dy="6" stdDeviation="18" flood-color="#000" flood-opacity=".55"/>
-    </filter>
   </defs>
-  <!-- Shadow layer -->
-  <rect x="128" y="128" width="768" height="768" rx="178" fill="#000" filter="url(#sh)"/>
   <!-- Background -->
   <rect x="128" y="128" width="768" height="768" rx="178" fill="url(#bg)"/>
   <!-- Top highlight -->


### PR DESCRIPTION
## What
Adds **InHive** to the supported-clients registry (`src/data/clients.ts`) with its logo (`static/clients/logo/inhive-dark.svg`).

## About
[InHive](https://inhive.ru) is a sing-box-based VPN client with public release repos under [github.com/TwilgateLabs](https://github.com/TwilgateLabs) (`inhive-android`, `inhive-windows`; iOS soon). Its sing-box core supports Reality / Hysteria2 / TUIC, and it sends the standard HWID + device headers (`x-hwid`, `x-device-os`, `x-device-model`, `x-ver-os`), so the HWID device-limit and device card work out of the box.

- `core: 'singbox'`, platforms android + windows (the two with public release binaries today), `hwid` badge.
- Download links point to the public TwilgateLabs release repos.

Companion to remnawave/templates#82 (adds InHive's UA to the default sing-box SRR rule so it receives the SINGBOX template).