### PR TITLE
Add application/wasm type to gzip-types (docs/reverse-proxies/nginx)

### DIFF
--- a/docs/install/reverse-proxies/nginx.md
+++ b/docs/install/reverse-proxies/nginx.md
@@ -151,6 +151,7 @@ server {
         application/rss+xml
         application/xhtml+xml
         application/xml
+        application/wasm
         font/eot
         font/otf
         font/ttf


### PR DESCRIPTION
After the 3.0 update, the Node Profile Editor loads WebAssembly very slowly.
Adding application/wasm to gzip_types fixes the issue.