### PR TITLE
docs: update Flowvy repository links

### DIFF
--- a/docs/awesome-remnawave.mdx
+++ b/docs/awesome-remnawave.mdx
@@ -513,10 +513,10 @@ import InfraBillingGuide from '/docs/awesome-remnawave/\_install-guides/infra-bi
         author="x_kit_"
         authorLink="https://github.com/this-xkit"
         image="/awesome/flowvy.webp"
-        githubRepo="flowvy-proxy/desktop"
+        githubRepo="flowvy/desktop"
         hwidSupported={true}
         links={{
-            github: 'https://github.com/flowvy-proxy/desktop',
+            github: 'https://github.com/flowvy/desktop',
             telegram: 'https://t.me/flowvy_client',
             website: 'https://docs.flowvy.io'
         }}

--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -383,19 +383,19 @@ export const CLIENTS: Client[] = [
         platforms: ['windows', 'macos', 'linux'],
         description: 'A polished Mihomo client with the two-click ease of a commercial VPN app.',
         logo: '/clients/logo/flowvy-dark.svg',
-        githubRepo: 'flowvy-proxy/desktop',
+        githubRepo: 'flowvy/desktop',
         badges: {
             hwid: true,
             featured: true
         },
         downloadLinks: {
             windows:
-                'https://github.com/flowvy-proxy/desktop/releases/latest/download/Flowvy_x64.exe',
-            macos: 'https://github.com/flowvy-proxy/desktop/releases/latest',
-            linux: 'https://github.com/flowvy-proxy/desktop/releases/latest/download/Flowvy_x64.deb'
+                'https://github.com/flowvy/desktop/releases/latest/download/Flowvy_x64.exe',
+            macos: 'https://github.com/flowvy/desktop/releases/latest',
+            linux: 'https://github.com/flowvy/desktop/releases/latest/download/Flowvy_x64.deb'
         },
         links: {
-            github: 'https://github.com/flowvy-proxy/desktop',
+            github: 'https://github.com/flowvy/desktop',
             telegram: 'https://t.me/flowvy_client',
             docs: 'https://docs.flowvy.io'
         }


### PR DESCRIPTION
Updates the Flowvy repository and download links after the GitHub organization was renamed from `flowvy-proxy` to `flowvy`.

The client catalog and Awesome Remnawave entry now point to https://github.com/flowvy/desktop.