### PR TITLE
docs: update links for Xray Checker Statuspage and Subscription Middleware

### DIFF
--- a/docs/awesome-remnawave.mdx
+++ b/docs/awesome-remnawave.mdx
@@ -95,8 +95,8 @@ import InfraBillingGuide from '/docs/awesome-remnawave/\_install-guides/infra-bi
         image="/awesome/xray-checker-statuspage.webp"
         githubRepo="Mrvibecodic/xray-checker-statuspage"
         links={{
-            github: 'https://github.com/Mrvibecodic/xray-checker-statuspage/tree/go-build',
-            telegram: 'https://t.me/+O5jAhwcYdYhlY2Yy'
+            github: 'https://github.com/Mrvibecodic/xray-checker-statuspage',
+            telegram: 'https://t.me/+FTC47eQY-NZkYjIy'
         }}
     >
         <XrayCheckerStatuspageGuide />
@@ -450,7 +450,7 @@ import InfraBillingGuide from '/docs/awesome-remnawave/\_install-guides/infra-bi
         githubRepo="Mrvibecodic/remnawave-subscription-middleware"
         links={{
             github: 'https://github.com/Mrvibecodic/remnawave-subscription-middleware',
-            telegram: 'https://t.me/+GTkYbwX3alg0ZGEy'
+            telegram: 'https://t.me/+FTC47eQY-NZkYjIy'
         }}
     />
 


### PR DESCRIPTION
- Xray Checker Statuspage (Go) — repo link now points to the repository root, Telegram link updated
- Remnawave Subscription Middleware — Telegram link updated

Three link values changed in `docs/awesome-remnawave.mdx`, nothing else.